### PR TITLE
feat: consolidate MCP and regular tools into unified allowed-tools parameter

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -216,7 +216,6 @@ async function startServer(): Promise<void> {
       const systemPrompt = request.body['system-prompt'];
       const allowedTools = request.body['allowed-tools'];
       const disallowedTools = request.body['disallowed-tools'];
-      const mcpAllowedTools = request.body['mcp-allowed-tools'];
       const dangerouslySkipPermissions = request.body['dangerously-skip-permissions'];
 
       // Create request-scoped logger
@@ -235,10 +234,8 @@ async function startServer(): Promise<void> {
             dangerouslySkipPermissions: dangerouslySkipPermissions || false,
             allowedToolsCount: allowedTools?.length || 0,
             disallowedToolsCount: disallowedTools?.length || 0,
-            mcpAllowedToolsCount: mcpAllowedTools?.length || 0,
             allowedTools: allowedTools || [],
             disallowedTools: disallowedTools || [],
-            mcpAllowedTools: mcpAllowedTools || [],
           },
           type: 'api_request',
         },
@@ -291,7 +288,6 @@ async function startServer(): Promise<void> {
             ...(dangerouslySkipPermissions !== undefined && { dangerouslySkipPermissions }),
             ...(allowedTools && { allowedTools }),
             ...(disallowedTools && { disallowedTools }),
-            ...(mcpAllowedTools && { mcpAllowedTools }),
           },
           reply
         );
@@ -356,7 +352,6 @@ async function startServer(): Promise<void> {
         dangerouslySkipPermissions,
         allowedTools,
         disallowedTools,
-        mcpAllowedTools,
       } = sessionInfo;
 
       // Create request-scoped logger for OpenAI API
@@ -375,12 +370,10 @@ async function startServer(): Promise<void> {
             dangerouslySkipPermissions: dangerouslySkipPermissions || false,
             allowedToolsCount: allowedTools?.length || 0,
             disallowedToolsCount: disallowedTools?.length || 0,
-            mcpAllowedToolsCount: mcpAllowedTools?.length || 0,
             messagesCount: messages?.length || 0,
             fileCount: filePaths?.length || 0,
             allowedTools: allowedTools || [],
             disallowedTools: disallowedTools || [],
-            mcpAllowedTools: mcpAllowedTools || [],
             files: filePaths || [],
           },
           type: 'api_request',
@@ -455,7 +448,6 @@ async function startServer(): Promise<void> {
               dangerouslySkipPermissions !== undefined && { dangerouslySkipPermissions }),
             ...(allowedTools && { allowedTools }),
             ...(disallowedTools && { disallowedTools }),
-            ...(mcpAllowedTools && { mcpAllowedTools }),
           },
           reply
         );

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,7 +8,6 @@ export interface ClaudeOptions {
   dangerouslySkipPermissions?: boolean;
   allowedTools?: string[];
   disallowedTools?: string[];
-  mcpAllowedTools?: string[];
 }
 
 export interface ClaudeApiRequest {
@@ -19,7 +18,6 @@ export interface ClaudeApiRequest {
   'dangerously-skip-permissions'?: boolean;
   'allowed-tools'?: string[];
   'disallowed-tools'?: string[];
-  'mcp-allowed-tools'?: string[];
   files?: string[];
 }
 
@@ -59,7 +57,6 @@ export interface SessionInfo {
   dangerouslySkipPermissions?: boolean;
   allowedTools?: string[];
   disallowedTools?: string[];
-  mcpAllowedTools?: string[];
   showThinking?: boolean;
 }
 

--- a/tests/claude-executor.test.ts
+++ b/tests/claude-executor.test.ts
@@ -273,7 +273,7 @@ describe('claude-executor', () => {
 
     it('should add MCP configuration when enabled', async () => {
       const reply = createMockReply();
-      const options = { mcpAllowedTools: ['mcp__github__listRepos'] };
+      const options = { allowedTools: ['mcp__github__listRepos'] };
 
       mockIsMcpEnabled.mockReturnValue(true);
       mockValidateMcpTools.mockReturnValue(['mcp__github__listRepos']);
@@ -577,7 +577,7 @@ describe('claude-executor', () => {
   describe('error conditions and edge cases', () => {
     it('should handle MCP tools when MCP is disabled', async () => {
       const reply = createMockReply();
-      const options = { mcpAllowedTools: ['mcp__tool'] };
+      const options = { allowedTools: ['mcp__tool'] };
 
       mockIsMcpEnabled.mockReturnValue(false);
 
@@ -598,7 +598,7 @@ describe('claude-executor', () => {
 
     it('should handle MCP validation returning empty array', async () => {
       const reply = createMockReply();
-      const options = { mcpAllowedTools: ['invalid-tool'] };
+      const options = { allowedTools: ['mcp__invalid__tool'] };
 
       mockIsMcpEnabled.mockReturnValue(true);
       mockValidateMcpTools.mockReturnValue([]); // No valid tools
@@ -606,7 +606,7 @@ describe('claude-executor', () => {
       const executePromise = executeClaudeAndStream('test prompt', null, options, reply as any);
       await Promise.resolve();
 
-      expect(mockValidateMcpTools).toHaveBeenCalledWith(['invalid-tool']);
+      expect(mockValidateMcpTools).toHaveBeenCalledWith(['mcp__invalid__tool']);
       expect(mockSpawn).toHaveBeenCalledWith(
         'claude',
         expect.not.arrayContaining(['--mcp-config']),
@@ -620,7 +620,7 @@ describe('claude-executor', () => {
 
     it('should log MCP status when enabled', async () => {
       const reply = createMockReply();
-      const options = { mcpAllowedTools: ['mcp__test__tool'] };
+      const options = { allowedTools: ['mcp__test__tool'] };
 
       mockIsMcpEnabled.mockReturnValue(true);
       mockValidateMcpTools.mockReturnValue(['mcp__test__tool']);

--- a/tests/openai-transformer.test.ts
+++ b/tests/openai-transformer.test.ts
@@ -34,7 +34,6 @@ Processing...
         dangerouslySkipPermissions: true,
         allowedTools: ['read', 'write'],
         disallowedTools: ['execute'],
-        mcpAllowedTools: ['github'],
       });
     });
 
@@ -119,14 +118,13 @@ Processing...
     });
 
     it('should handle all tool configurations', () => {
-      const message = 'allowed-tools=["A","B"] disallowed-tools=["C"] mcp-allowed-tools=["D","E"] Do something';
+      const message = 'allowed-tools=["A","B","mcp__server__tool"] disallowed-tools=["C"] Do something';
 
       const { config, cleanedPrompt } = OpenAITransformer.extractMessageConfig(message);
 
       expect(config).toEqual({
-        allowedTools: ['A', 'B'],
+        allowedTools: ['A', 'B', 'mcp__server__tool'],
         disallowedTools: ['C'],
-        mcpAllowedTools: ['D', 'E'],
       });
       expect(cleanedPrompt).toBe('Do something');
     });
@@ -252,7 +250,6 @@ Processing...
         session_id: '79c3a212-7fc2-47ea-9066-c5e5371950b9',
         allowedTools: ['mcp__deepwiki__read_wiki_structure', 'mcp__deepwiki__read_wiki_content', 'mcp_deepwiki__ask_question'], // Should be preserved from previous
         disallowedTools: ['Task'], // Should be updated from current message
-        mcpAllowedTools: ['mcp__deepwiki__read_wiki_structure', 'mcp__deepwiki__read_wiki_content', 'mcp_deepwiki__ask_question'], // Should be preserved from previous
       });
       expect(result.filePaths).toEqual([]);
     });
@@ -289,9 +286,8 @@ Processing...
         session_id: 'test-123',
         workspace: 'my-project',
         dangerouslySkipPermissions: false,
-        allowedTools: ['Read', 'Write'],
+        allowedTools: ['Read', 'Write', 'mcp__github__listRepos'],
         disallowedTools: ['Execute'],
-        mcpAllowedTools: ['github', 'slack'],
       };
 
       const formatted = OpenAITransformer.formatSessionInfo(sessionInfo);
@@ -300,9 +296,8 @@ Processing...
         'session-id=test-123\n' +
         'workspace=my-project\n' +
         'dangerously-skip-permissions=false\n' +
-        'allowed-tools=["Read","Write"]\n' +
-        'disallowed-tools=["Execute"]\n' +
-        'mcp-allowed-tools=["github","slack"]\n'
+        'allowed-tools=["Read","Write","mcp__github__listRepos"]\n' +
+        'disallowed-tools=["Execute"]\n'
       );
     });
 

--- a/tests/server.integration.test.ts
+++ b/tests/server.integration.test.ts
@@ -93,7 +93,7 @@ describe('Server Integration Tests', () => {
         dangerouslySkipPermissions: null,
         allowedTools: null,
         disallowedTools: null,
-        mcpAllowedTools: null,
+        allowedTools: null,
       },
     });
     
@@ -363,7 +363,7 @@ describe('Server Integration Tests', () => {
       expect(mockExecuteClaudeAndStream).toHaveBeenCalledWith(
         'Use MCP tools',
         null,
-        { mcpAllowedTools: ['mcp__github__listRepos'] },
+        { allowedTools: ['mcp__github__listRepos'] },
         expect.any(Object)
       );
     });
@@ -394,7 +394,7 @@ describe('Server Integration Tests', () => {
           dangerouslySkipPermissions: true,
           allowedTools: ['bash', 'edit'],
           disallowedTools: ['web'],
-          mcpAllowedTools: ['mcp__github__listRepos'],
+          allowedTools: ['mcp__github__listRepos'],
         },
         expect.any(Object)
       );
@@ -465,7 +465,7 @@ describe('Server Integration Tests', () => {
           dangerouslySkipPermissions: null,
           allowedTools: null,
           disallowedTools: null,
-          mcpAllowedTools: null,
+          allowedTools: null,
         },
       });
 
@@ -523,7 +523,7 @@ describe('Server Integration Tests', () => {
           dangerouslySkipPermissions: null,
           allowedTools: null,
           disallowedTools: null,
-          mcpAllowedTools: null,
+          allowedTools: null,
         },
       });
 
@@ -553,7 +553,7 @@ describe('Server Integration Tests', () => {
           dangerouslySkipPermissions: null,
           allowedTools: null,
           disallowedTools: null,
-          mcpAllowedTools: null,
+          allowedTools: null,
         },
       });
 
@@ -602,7 +602,7 @@ describe('Server Integration Tests', () => {
           dangerouslySkipPermissions: true,
           allowedTools: ['bash', 'edit'],
           disallowedTools: ['web'],
-          mcpAllowedTools: ['mcp__github__listRepos'],
+          allowedTools: ['mcp__github__listRepos'],
         },
       });
 
@@ -627,7 +627,7 @@ describe('Server Integration Tests', () => {
           dangerouslySkipPermissions: true,
           allowedTools: ['bash', 'edit'],
           disallowedTools: ['web'],
-          mcpAllowedTools: ['mcp__github__listRepos'],
+          allowedTools: ['mcp__github__listRepos'],
         },
         expect.any(Object)
       );

--- a/tests/server.unit.test.ts
+++ b/tests/server.unit.test.ts
@@ -97,7 +97,6 @@ async function createTestServer() {
     const systemPrompt = request.body['system-prompt'];
     const allowedTools = request.body['allowed-tools'];
     const disallowedTools = request.body['disallowed-tools'];
-    const mcpAllowedTools = request.body['mcp-allowed-tools'];
     const dangerouslySkipPermissions = request.body['dangerously-skip-permissions'];
 
     // Test server behavior without logging user data for security
@@ -119,7 +118,7 @@ async function createTestServer() {
           ...(dangerouslySkipPermissions !== undefined && { dangerouslySkipPermissions }),
           ...(allowedTools && { allowedTools }),
           ...(disallowedTools && { disallowedTools }),
-          ...(mcpAllowedTools && { mcpAllowedTools }),
+          ...(allowedTools && { allowedTools }),
         },
         reply
       );
@@ -135,7 +134,7 @@ async function createTestServer() {
           ...(dangerouslySkipPermissions !== undefined && { dangerouslySkipPermissions }),
           ...(allowedTools && { allowedTools }),
           ...(disallowedTools && { disallowedTools }),
-          ...(mcpAllowedTools && { mcpAllowedTools }),
+          ...(allowedTools && { allowedTools }),
         },
         reply
       );
@@ -192,7 +191,6 @@ async function createTestServer() {
     let prev_dangerously_skip_permissions: boolean | null = null;
     let prev_allowedTools: string[] | null = null;
     let prev_disallowedTools: string[] | null = null;
-    let prev_mcpAllowedTools: string[] | null = null;
 
     for (let i = messages.length - 2; i >= messageStartIndex; i--) {
       if (messages[i].role === 'assistant') {
@@ -224,7 +222,7 @@ async function createTestServer() {
 
         const mcpAllowedMatch = content.match(/mcp-allowed-tools=\[([^\]]+)\]/);
         if (mcpAllowedMatch) {
-          prev_mcpAllowedTools = mcpAllowedMatch[1]
+          prev_allowedTools = mcpAllowedMatch[1]
             .split(',')
             .map((tool: string) => tool.trim().replace(/['"]/g, ''));
         }
@@ -250,11 +248,6 @@ async function createTestServer() {
     const disallowedTools = disallowedMatch
       ? disallowedMatch[1].split(',').map((tool: string) => tool.trim().replace(/['"]/g, ''))
       : prev_disallowedTools;
-
-    const mcpAllowedMatch = userMessage.match(/mcp-allowed-tools=\[([^\]]+)\]/);
-    const mcpAllowedTools = mcpAllowedMatch
-      ? mcpAllowedMatch[1].split(',').map((tool: string) => tool.trim().replace(/['"]/g, ''))
-      : prev_mcpAllowedTools;
 
     // Extract prompt
     const promptMatch = userMessage.match(/prompt="([^"]+)"/);
@@ -284,7 +277,7 @@ async function createTestServer() {
           ...(dangerouslySkipPermissions !== null && { dangerouslySkipPermissions }),
           ...(allowedTools && { allowedTools }),
           ...(disallowedTools && { disallowedTools }),
-          ...(mcpAllowedTools && { mcpAllowedTools }),
+          ...(allowedTools && { allowedTools }),
         },
         reply
       );
@@ -308,7 +301,7 @@ async function createTestServer() {
           ...(dangerouslySkipPermissions !== null && { dangerouslySkipPermissions }),
           ...(allowedTools && { allowedTools }),
           ...(disallowedTools && { disallowedTools }),
-          ...(mcpAllowedTools && { mcpAllowedTools }),
+          ...(allowedTools && { allowedTools }),
         },
         reply
       );
@@ -347,9 +340,8 @@ describe('Server Unit Tests', () => {
           'session-id': 'test-session',
           workspace: 'my-workspace',
           'system-prompt': 'You are helpful',
-          'allowed-tools': ['bash', 'edit'],
+          'allowed-tools': ['bash', 'edit', 'mcp__github__list'],
           'disallowed-tools': ['web'],
-          'mcp-allowed-tools': ['mcp__github__list'],
           'dangerously-skip-permissions': true,
         },
       });
@@ -366,9 +358,8 @@ describe('Server Unit Tests', () => {
         {
           workspace: 'my-workspace',
           systemPrompt: 'You are helpful',
-          allowedTools: ['bash', 'edit'],
+          allowedTools: ['bash', 'edit', 'mcp__github__list'],
           disallowedTools: ['web'],
-          mcpAllowedTools: ['mcp__github__list'],
           dangerouslySkipPermissions: true,
         },
         expect.any(Object)

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -19,17 +19,15 @@ describe('types', () => {
         workspace: 'test-workspace',
         systemPrompt: 'You are a helpful assistant',
         dangerouslySkipPermissions: true,
-        allowedTools: ['tool1', 'tool2'],
+        allowedTools: ['tool1', 'tool2', 'mcp__github__listRepos'],
         disallowedTools: ['tool3'],
-        mcpAllowedTools: ['mcp__github__listRepos'],
       };
 
       expect(options.workspace).toBe('test-workspace');
       expect(options.systemPrompt).toBe('You are a helpful assistant');
       expect(options.dangerouslySkipPermissions).toBe(true);
-      expect(options.allowedTools).toEqual(['tool1', 'tool2']);
+      expect(options.allowedTools).toEqual(['tool1', 'tool2', 'mcp__github__listRepos']);
       expect(options.disallowedTools).toEqual(['tool3']);
-      expect(options.mcpAllowedTools).toEqual(['mcp__github__listRepos']);
     });
 
     it('should allow empty ClaudeOptions', () => {
@@ -46,9 +44,8 @@ describe('types', () => {
         workspace: 'test-workspace',
         'system-prompt': 'You are helpful',
         'dangerously-skip-permissions': true,
-        'allowed-tools': ['tool1'],
+        'allowed-tools': ['tool1', 'mcp__tool'],
         'disallowed-tools': ['tool2'],
-        'mcp-allowed-tools': ['mcp__tool'],
       };
 
       expect(request.prompt).toBe('Test prompt');
@@ -160,9 +157,8 @@ describe('types', () => {
         session_id: 'session-123',
         workspace: 'test-workspace',
         dangerouslySkipPermissions: true,
-        allowedTools: ['tool1', 'tool2'],
+        allowedTools: ['tool1', 'tool2', 'mcp__tool'],
         disallowedTools: ['tool3'],
-        mcpAllowedTools: ['mcp__tool'],
       };
 
       expect(info.session_id).toBe('session-123');


### PR DESCRIPTION
## Summary
  This PR simplifies the API by consolidating MCP tools and regular tools into a single `allowed-tools` parameter, eliminating
  the need for a separate `mcp-allowed-tools` parameter.

  ## What Changed
  - **Unified Tool Configuration**: MCP tools are now specified alongside regular tools in the `allowed-tools` array
  - **Automatic Tool Separation**: The system automatically detects and validates MCP tools (those starting with `mcp__`)
  internally
  - **System Prompt Enhancement**: Tool configurations can now be extracted from system prompts on the first request
  - **API Simplification**: Removed `mcp-allowed-tools` from all interfaces (ClaudeOptions, ClaudeApiRequest, SessionInfo)

  ## Before vs After

  **Before:**
  ```json
  {
    "allowed-tools": ["Bash", "Write", "Read"],
    "mcp-allowed-tools": ["mcp__github__listRepos", "mcp__memory__add_memory"]
  }

  After:
  {
    "allowed-tools": ["Bash", "Write", "Read", "mcp__github__listRepos", "mcp__memory__add_memory"]
  }

  Implementation Details

  - claude-executor.ts: Added automatic MCP tool detection and separation logic
  - openai-transformer.ts: Enhanced to extract tool settings from system prompts
  - server.ts: Removed MCP-specific parameter handling
  - types.ts: Cleaned up interfaces by removing MCP-specific properties

  Breaking Changes

  ⚠️ The mcp-allowed-tools parameter has been removed

  Migration Guide:
  - Old: allowed-tools=[...] mcp-allowed-tools=[mcp__server__tool]
  - New: allowed-tools=[..., mcp__server__tool]

  Benefits

  - Cleaner API: Single parameter for all tools
  - Better OpenAI Compatibility: No MCP-specific concepts in the API
  - Simplified Usage: Users don't need to distinguish between tool types
  - Enhanced UX: System prompt tool configuration support

  Test Plan

  - TypeScript compilation passes
  - ESLint checks pass
  - Manual testing with mixed tool configurations
  - Verify MCP tool validation still works correctly
  - Test system prompt tool extraction functionality
