### PR TITLE
fix: remove unnecessary MCP tool validation

### DIFF
--- a/tests/claude-executor.test.ts
+++ b/tests/claude-executor.test.ts
@@ -281,7 +281,6 @@ describe('claude-executor', () => {
       const executePromise = executeClaudeAndStream('test prompt', null, options, reply as any);
       await Promise.resolve();
 
-      expect(mockValidateMcpTools).toHaveBeenCalledWith(['mcp__github__listRepos']);
       expect(mockSpawn).toHaveBeenCalledWith(
         'claude',
         expect.arrayContaining([
@@ -596,20 +595,23 @@ describe('claude-executor', () => {
       await executePromise;
     });
 
-    it('should handle MCP validation returning empty array', async () => {
+    it('should add MCP config even for potentially invalid tools', async () => {
       const reply = createMockReply();
       const options = { allowedTools: ['mcp__invalid__tool'] };
 
       mockIsMcpEnabled.mockReturnValue(true);
-      mockValidateMcpTools.mockReturnValue([]); // No valid tools
 
       const executePromise = executeClaudeAndStream('test prompt', null, options, reply as any);
       await Promise.resolve();
 
-      expect(mockValidateMcpTools).toHaveBeenCalledWith(['mcp__invalid__tool']);
       expect(mockSpawn).toHaveBeenCalledWith(
         'claude',
-        expect.not.arrayContaining(['--mcp-config']),
+        expect.arrayContaining([
+          '--mcp-config',
+          expect.stringContaining('mcp-config.json'),
+          '--allowedTools',
+          'mcp__invalid__tool'
+        ]),
         expect.any(Object)
       );
 


### PR DESCRIPTION
## Summary
  - Remove unnecessary `validateMcpTools` call from
  claude-executor
  - Pass MCP tools directly to Claude CLI without
  pre-validation
  - Let Claude CLI handle invalid tool names
  gracefully
  - Simplify code by removing complex tool filtering
   logic

  ## Problem Fixed
  This resolves cases where MCP tools would be
  silently excluded when:
  - MCP config not found at startup
  - Invalid tool names or typos in requests
  - Configuration path mismatches between MCP
  manager and executor
  - All requested MCP tools were deemed invalid

  ## Root Cause
  The previous implementation had a fatal flaw:
  1. MCP tools were separated from regular tools
  2. If `isMcpEnabled()` returned `false`, MCP
  validation was skipped
  3. `validMcpTools` remained empty array
  4. Only `validMcpTools` (empty) was included in
  final `allowedTools`
  5. Result: MCP tools disappeared from
  `--allowedTools` parameter
  6. Claude CLI would then report "No such tool
  available" errors

  ## Changes
  - **Simplified Logic**: Remove tool separation and
   validation steps
  - **Direct Pass-through**: All `allowedTools` are
  passed directly to Claude CLI
  - **Better Error Handling**: Let Claude CLI report
   "No such tool available" errors directly
  - **Test Updates**: Updated tests to reflect new
  behavior

  ## Before vs After

  ### Before (Problematic):
  ```javascript
  // User request
  allowedTools: ["Read",
  "mcp__hanon_memory__search_memory_nodes"]

  // If MCP disabled/invalid
  allAllowedTools = [...["Read"], ...[]]  // MCP
  tools lost!
  // → claude --allowedTools Read
  // → "No such tool available:
  mcp__hanon_memory__search_memory_nodes"

  After (Fixed):

  // User request
  allowedTools: ["Read",
  "mcp__hanon_memory__search_memory_nodes"]

  // Direct pass-through
  // → claude --allowedTools
  Read,mcp__hanon_memory__search_memory_nodes
  --mcp-config path/to/config.json
  // → Claude CLI handles invalid tools
  appropriately

  Test Results

  - ✅ All unit tests pass
  - ✅ All E2E tests pass
  - ✅ Type checking and linting pass

  Breaking Changes

  None - this is a bug fix that improves
  reliability.

  🤖 Generated with https://claude.ai/code

  **Files Changed:**
  - `src/claude-executor.ts` - Removed validation
  logic, simplified tool handling
  - `tests/claude-executor.test.ts` - Updated test
  expectations for new behavior